### PR TITLE
catch syntax errors in eval_content

### DIFF
--- a/lib/oas_core/yard/oas_core_factory.rb
+++ b/lib/oas_core/yard/oas_core_factory.rb
@@ -115,7 +115,7 @@ module OasCore
       # rubocop:disable Security/Eval
       def eval_content(content)
         eval(content)
-      rescue StandardError
+      rescue StandardError, SyntaxError
         {}
       end
       # rubocop:enable Security/Eval


### PR DESCRIPTION
In eval_content the eval statement was being caught by StandardError but SyntaxErrors could also result so they have been added to the rescue statement so that an empty hash is returned when eval is unsuccessful