### PR TITLE
Use rails compatible deep_merge version to prevent conflicts

### DIFF
--- a/lib/oas_core.rb
+++ b/lib/oas_core.rb
@@ -3,7 +3,7 @@
 require 'yard'
 require 'method_source'
 require 'active_support/all'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module OasCore
   require 'oas_core/version'
@@ -98,7 +98,7 @@ module OasCore
     def build(oas_routes, oas_source: {})
       oas = Builders::SpecificationBuilder.new.with_oas_routes(oas_routes).build.to_spec
 
-      oas_source.deep_merge(oas, merge_hash_arrays: true, extend_existing_arrays: true)
+      oas_source.deeper_merge(oas, merge_hash_arrays: true, extend_existing_arrays: true)
     end
   end
 end


### PR DESCRIPTION
The `deep_merge` method from the gem conflicts with ActiveSupport's `deep_merge` gem. Our tests started failing on deep_merge after we upgraded to 1.0.0.

Expected result:
```
> { a: { b: 1 } }.deep_merge(a: { b: 2 })
=> {a: {b: 2}}
```

Actual result (**oas_core 1.0.0**):
```
> { a: { b: 1 } }.deep_merge(a: { b: 2 })
=> {a: {b: 1}}
```

The deep_merge gem offers a [solution](https://github.com/danielsdeleo/deep_merge?tab=readme-ov-file#using-deep_merge-in-rails) for this conflict. We should use `deep_merge/rails_compat` that introduces a `deeper_merge` method, instead of deep_merge.