### PR TITLE
feat: add support for keywords in parameters (ex: default)

### DIFF
--- a/docs/src/tags/parameter.md
+++ b/docs/src/tags/parameter.md
@@ -1,23 +1,53 @@
 # @parameter
 
-**Structure**: `@parameter name(position) [type] text`
+**Structure**: `@parameter name(position) [type] text [keyword: (value)]`
 
 Represents a parameter for the endpoint. The position can be one of the following: `header`, `path`, `cookie`, or `query`. The type should be a valid Ruby class, such as `String`, `Integer`, or `Array<String>`. Prefix the class with a `!` to indicate a required parameter.
 
+### Supported Keywords in Descriptions
+
+You can include additional schema keywords in the description using the format `keyword: (value)`. The following keywords are supported:
+
+- **`default`**: The default value for the parameter.  
+  Example: `default: (1)`
+- **`minimum`**: The minimum value for numeric parameters.  
+  Example: `minimum: (0)`
+- **`maximum`**: The maximum value for numeric parameters.  
+  Example: `maximum: (100)`
+- **`enum`**: A comma-separated list of allowed values.  
+  Example: `enum: (red,green,blue)`
+- **`format`**: The format of the parameter (e.g., `date`, `uuid`).  
+  Example: `format: (uuid)`
+- **`pattern`**: A regex pattern for string validation.  
+  Example: `pattern: (^[A-Za-z]+$)`
+- **`nullable`**: Whether the parameter can be `null` (`true` or `false`).  
+  Example: `nullable: (true)`
+- **`exclusiveMinimum`**: Whether the `minimum` is exclusive (`true` or `false`).  
+  Example: `exclusiveMinimum: (true)`
+- **`exclusiveMaximum`**: Whether the `maximum` is exclusive (`true` or `false`).  
+  Example: `exclusiveMaximum: (false)`
+- **`minLength`**: The minimum length for string parameters.  
+  Example: `minLength: (3)`
+- **`maxLength`**: The maximum length for string parameters.  
+  Example: `maxLength: (50)`
+
 **Examples**:
 
-`# @parameter page(query) [Integer] The page number.`
+```ruby
+# Basic usage
+# @parameter page(query) [!Integer] The page number. default: (1) minimum: (0)
 
-`# @parameter slug(path) [!String] The slug of the project.`
+# Enum and nullable
+# @parameter color(query) [String] The color of the item. enum: (red,green,blue) nullable: (true)
 
-### Reference
-
-This tag also supports a reference for its schema. The reference can point to any external or internal resource, following the OpenAPI Specification (OAS) definition: <https://spec.openapis.org/oas/v3.1.0.html#schema-object>.
-
-The reference should be formatted as follows:
+# String validation
+# @parameter username(path) [String] The username. pattern: (^[A-Za-z0-9_]+$), minLength: (3), maxLength: (20)
 
 ```
-# @parameter page(query) [Reference:#/components/schema/pageQueryParam]
-```
 
-Note that the reference applies to the schema, not the entire parameter. To reference the complete parameter, use the `@parameter_ref` tag.
+## From Swagger docs: Common Mistakes
+
+There are two common mistakes when using the default keyword:
+
+- Using default with required parameters or properties, for example, with path parameters. This does not make sense – if a value is required, the client must always send it, and the default value is never used.
+- Using default to specify a sample value. This is not intended use of default and can lead to unexpected behavior in some Swagger tools. Use the example or examples keyword for this purpose instead. See Adding Examples.

--- a/test/lib/oas_core/yard/oas_core_factory_test.rb
+++ b/test/lib/oas_core/yard/oas_core_factory_test.rb
@@ -64,7 +64,7 @@ module OasCore
       end
 
       def test_parse_tag_with_parameter_returns_parameter_tag_with_all_attributes
-        text = 'id(path) [!Integer] The user ID'
+        text = 'id(path) [!Integer] The user ID default: (1) minimum: (0) enum: (1,2,3,4,5) nullable: (true)'
         tag = @factory.parse_tag_with_parameter('parameter', text)
 
         assert_instance_of ParameterTag, tag
@@ -74,7 +74,7 @@ module OasCore
         assert_equal 'path', tag.location
         assert_equal true, tag.required
         assert_nil tag.types
-        assert_equal({ type: 'integer' }, tag.schema)
+        assert_equal({ type: 'integer', default: '1', minimum: '0', enum: %w[1 2 3 4 5], nullable: true }, tag.schema)
       end
 
       def test_parse_tag_with_parameter_appends_brackets_to_query_array_parameters


### PR DESCRIPTION
This should close this PR in OasRails: https://github.com/a-chacon/oas_rails/issues/153