### PR TITLE
fix: make component hash keys deterministic across processes

### DIFF
--- a/lib/oas_core/spec/hashable.rb
+++ b/lib/oas_core/spec/hashable.rb
@@ -31,9 +31,13 @@ module OasCore
         when Array
           obj.map { |v| hash_representation_recursive(v) }
         when Hashable
-          obj.hash_representation
+          hash_representation_recursive(obj.hash_representation)
         else
-          obj
+          # Objects that serialize to a spec (e.g. MediaType) are hashed by
+          # their serialized form. Falling through to the default branch would
+          # embed their `inspect` output — memory address included — making
+          # the digest different on every run.
+          obj.respond_to?(:to_spec) ? hash_representation_recursive(obj.to_spec) : obj
         end
       end
     end

--- a/test/lib/oas_core/spec/hashable_test.rb
+++ b/test/lib/oas_core/spec/hashable_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module OasCore
+  module Spec
+    class HashableTest < Minitest::Test
+      def setup
+        @specification = Specification.new
+      end
+
+      def build_response
+        media_type = MediaType.new(@specification)
+        media_type.schema = { type: 'object', properties: { error: { type: 'string' } } }
+        media_type.examples = { example: { value: { error: 'unauthorized' } } }
+
+        response = Response.new(@specification)
+        response.code = 401
+        response.description = 'Missing or invalid API key'
+        response.content = { 'application/json': media_type }
+        response
+      end
+
+      def test_hash_key_is_stable_across_equal_object_graphs
+        # Two separately built but structurally identical responses must share
+        # a hash key. Before the fix, the MediaType inside content fell through
+        # to `inspect` — memory address included — so every instance (and every
+        # process) produced a different digest: committed specs churned on each
+        # regeneration, and identical responses never deduplicated.
+        assert_equal build_response.hash_key, build_response.hash_key
+      end
+
+      def test_hash_key_changes_when_content_changes
+        other = build_response
+        other.content[:'application/json'].schema = { type: 'string' }
+
+        refute_equal build_response.hash_key, other.hash_key
+      end
+
+      def test_hash_key_recurses_nested_hashables
+        # A Hashable nested inside another Hashable's representation must be
+        # reduced to plain data too, not left as a live object.
+        parameter = Parameter.new(@specification)
+        parameter.name = 'kind'
+        parameter.in = 'path'
+
+        representation = Hashable.hash_representation_recursive({ parameter: parameter })
+
+        assert_kind_of Hash, representation[:parameter]
+        refute_match(/0x[0-9a-f]+/, representation.to_s)
+      end
+
+      def test_hash_representation_has_no_object_addresses
+        representation = Hashable.hash_representation_recursive(build_response.hash_representation)
+
+        refute_match(/0x[0-9a-f]+/, representation.to_s)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`Hashable#hash_key` MD5-digests `hash_representation_recursive(...).to_s` — but the structure being stringified can still contain **live objects**, in two ways:

1. **Objects that are `Specable` but not `Hashable`** — e.g. the `MediaType` instances inside `Response#content` — fall through to the `else` branch and are embedded as-is, so `to_s` renders them via `inspect`, **memory address included**: `#<OasCore::Spec::MediaType:0x00007f...>`.
2. **A `Hashable` nested inside another `Hashable`'s representation** is returned as its raw representation without recursing into it, so live objects inside it leak the same way.

## User-visible consequences

- **Response component ids change on every generator run.** Anyone committing their generated spec (we commit `public/openapi.json` and serve it to a Scalar reference page) gets meaningless VCS churn on every regeneration — every id under `components/responses` rewrites itself.
- **Component dedup is broken for responses with content.** `Components#add_response` dedupes by `hash_key`, but two structurally identical responses never produce the same key (different addresses), so identical responses are never shared.

Reproduction — same object graph, two separate processes, v1.4.0:

```
d94d28789ed85e221228237adced3801
cb20ee412f52608b1cddf1e45fa22887
```

## The fix

In `hash_representation_recursive`:
- recurse into nested `Hashable` representations, and
- hash `Specable` objects by their **serialized form** (`to_spec`) — the same data that ends up in the emitted spec, which is exactly the identity a content-addressed component key should capture.

Parameter and request-body keys (already all-primitive) are unchanged, so existing stable ids stay stable — only the ids that were already nondeterministic change.

Same probe after the fix:

```
5fc5ba77bd264a66d326138700b79ce8
5fc5ba77bd264a66d326138700b79ce8
```

## Tests

Adds `test/lib/oas_core/spec/hashable_test.rb`: equal-graphs-equal-key (the dedup semantic), different-content-different-key, nested-Hashable recursion, and a no-object-addresses guard on the digested representation. Full suite: 111 tests, 285 assertions, 0 failures.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aof8N2bNNxmFisrm9dumsg