### PR TITLE
docs: fix @request_body_example format in examples

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
   # @no_auth
   #
   # @request_body The user to be created. At least include an `email`. [!User]
-  # @request_body_example basic user [Hash] {user: {name: "Luis", email: "luis@gmail.ocom"}}
+  # @request_body_example basic user [JSON{"user": {"name": "Luis", "email": "luis@gmail.com"}}]
   def create
     @user = User.new(user_params)
 
@@ -46,8 +46,8 @@ class UsersController < ApplicationController
   # - It must work
   # @tags users, update
   # @request_body User to be created [!Hash{user: { name: String, email: !String, age: Integer, available_dates: Array<Date>}}]
-  # @request_body_example Update user [Hash] {user: {name: "Luis", email: "luis@gmail.com"}}
-  # @request_body_example Complete User [Hash] {user: {name: "Luis", email: "luis@gmail.com", age: 21}}
+  # @request_body_example Update user [JSON{"user": {"name": "Luis", "email": "luis@gmail.com"}}]
+  # @request_body_example Complete User [JSON{"user": {"name": "Luis", "email": "luis@gmail.com", "age": 21}}]
   def update
     if @user.update(user_params)
       render json: @user


### PR DESCRIPTION
The `@request_body_example` examples in `docs/src/examples.md` show:

```ruby
# @request_body_example basic user [Hash] {user: {name: "Luis", email: "luis@gmail.ocom"}}
```

but `OasCoreFactory#split_description_and_type` requires the tag text to **end** with the bracketed type (`/^(.*?)\s*\[(.*?)\]$/` — `oas_core_factory.rb`), so copying these examples verbatim raises `TagParsingError: Invalid format` and the whole operation is silently dropped from the generated spec (that's how we hit it — our `POST /resolve` vanished from the docs page).

The working format is `description [JSON{...}]`, same as the response examples. Also fixes the `gmail.ocom` typo.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aof8N2bNNxmFisrm9dumsg